### PR TITLE
feat: allow fixed elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ class XDSceneNodeWrapper {
             locked: node.locked,
             markedForExport: node.markedForExport,
             hasLinkedContent: node.hasLinkedContent,
+            fixedWhenScrolling: node.fixedWhenScrolling,
             ...result
         };
     }


### PR DESCRIPTION
Adding support for `fixedWhenScrolling` presented in SceneNodes.

Reference:
https://adobexdplatform.com/plugin-docs/reference/scenegraph.html#scenenodefixedwhenscrolling--boolean